### PR TITLE
✨Feat: 로그인/회원가입/영수증/메인 대시보드 API 연동

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,8 +68,8 @@ Figma에서 내보낸 차트 SVG(`chart-group1~3.svg`)는 `width="100%" height="
   - 간호대학 : 핑크
   - 의과대학 : 검정
 
-## API 연동
-# ReCheck API 명세서
+# API 연동
+## ReCheck API 명세서
 
 > **Base URL**: `https://api.reajoucheck.site` 
 > **Content-Type**: `application/json` (파일 업로드 제외)
@@ -267,17 +267,68 @@ Figma에서 내보낸 차트 SVG(`chart-group1~3.svg`)는 `width="100%" height="
 
 ## 영수증 (Receipts)
 
-### 영수증 이미지 업로드
+### 영수증 OCR 분석
 
-**POST** `/api/receipts/upload` `🔒 인증 필요`
+**POST** `/api/receipts/analyze` `🔒 인증 필요`
 
 > `Content-Type: multipart/form-data`
+
+영수증 이미지를 OCR로 분석하여 결제 정보를 반환합니다. S3 업로드 및 DB 저장은 하지 않습니다.
+사용자가 OCR 결과를 확인한 뒤 `/confirm`을 호출해야 최종 저장됩니다.
 
 **Request (multipart/form-data)**
 
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|------|------|
 | `image` | File | O | 영수증 이미지 (.jpg, .jpeg, .png, .gif, .webp / 최대 5MB) |
+
+**Response**
+```json
+{
+  "success": true,
+  "code": 200,
+  "message": "요청이 성공적으로 처리되었습니다.",
+  "data": {
+    "storeName": "사랑집4",
+    "paymentAmount": 15000,
+    "cardCompany": "국민카드",
+    "confirmNum": "12345678"
+  }
+}
+```
+
+**에러 케이스**
+| 상태 | 메시지 |
+|------|--------|
+| `400` | 지원하지 않는 카드사 입니다. (국민카드만 허용) |
+| `409` | 이미 등록된 영수증입니다. |
+
+---
+
+### 영수증 업로드 확정
+
+**POST** `/api/receipts/confirm` `🔒 인증 필요`
+
+> `Content-Type: multipart/form-data`
+
+OCR 분석 결과를 사용자가 확인한 후 호출합니다. 이미지를 S3에 업로드하고 DB에 저장합니다.
+
+**Request (multipart/form-data)**
+
+| 필드 | 타입 | Content-Type | 필수 | 설명 |
+|------|------|--------------|------|------|
+| `image` | File | - | O | 영수증 이미지 (.jpg, .jpeg, .png, .gif, .webp / 최대 5MB) |
+| `data` | JSON | `application/json` | O | `/analyze` 응답의 OCR 결과 |
+
+`data` JSON 형식:
+```json
+{
+  "storeName": "사랑집4",
+  "paymentAmount": 15000,
+  "cardCompany": "국민카드",
+  "confirmNum": "12345678"
+}
+```
 
 **Response**
 ```json

--- a/src/api/receipts.js
+++ b/src/api/receipts.js
@@ -1,0 +1,27 @@
+import { apiRequest } from './client'
+
+// OCR 분석만 수행 — S3 업로드/DB 저장 없음
+export async function analyzeReceipt(imageFile) {
+  const formData = new FormData()
+  formData.append('image', imageFile)
+
+  return apiRequest('/api/receipts/analyze', {
+    method: 'POST',
+    body: formData,
+  })
+}
+
+// 사용자 확인 후 최종 저장 — S3 업로드 + DB 저장
+export async function confirmReceipt(imageFile, ocrData) {
+  const formData = new FormData()
+  formData.append('image', imageFile)
+  formData.append(
+    'data',
+    new Blob([JSON.stringify(ocrData)], { type: 'application/json' })
+  )
+
+  return apiRequest('/api/receipts/confirm', {
+    method: 'POST',
+    body: formData,
+  })
+}

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -1,0 +1,5 @@
+import { apiRequest } from './client'
+
+export async function getMyDashboard() {
+  return apiRequest('/api/users/me/dashboard')
+}

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import './Main.css'
 import AlertModal from '../components/AlertModal'
@@ -10,9 +10,7 @@ import ellipse189 from '../assets/icon/Ellipse 189.svg'
 import chartG1    from '../assets/image/chart-group1.svg'
 import chartG2    from '../assets/image/chart-group2.svg'
 import chartG3    from '../assets/image/chart-group3.svg'
-
-// TODO: API 연동 시 props 또는 전역 상태로 교체
-const USER = { name: '김아주', college: '경영대', spent: '230,000원' }
+import { getMyDashboard } from '../api/users'
 
 const DAYS   = ['월', '화', '수', '목', '금', '토', '일']
 const LEGEND = [
@@ -25,6 +23,18 @@ const LEGEND = [
 export default function Main() {
   const navigate = useNavigate()
   const [showBattleModal, setShowBattleModal] = useState(false)
+  const [user, setUser] = useState({ name: '', college: '', spent: '' })
+
+  useEffect(() => {
+    getMyDashboard()
+      .then(data => setUser({
+        name: data.name,
+        college: data.collegeName,
+        spent: `${data.totalPaymentAmount.toLocaleString()}원`,
+      }))
+      .catch(() => {})
+  }, [])
+
   return (
     <div className="main">
 
@@ -44,10 +54,10 @@ export default function Main() {
       <div className="main__card">
         <img className="main__card-asset" src={asset21} alt="" />
         <div className="main__card-mascot"><img src={mascotImg} alt="" /></div>
-        <p className="main__card-name">{USER.name}</p>
-        <p className="main__card-college">{USER.college}</p>
+        <p className="main__card-name">{user.name}</p>
+        <p className="main__card-college">{user.college}</p>
         <p className="main__card-label">지금까지 얼마 썼나요?</p>
-        <p className="main__card-amount">{USER.spent}</p>
+        <p className="main__card-amount">{user.spent}</p>
       </div>
 
       {/* ── 통계 ── */}
@@ -67,7 +77,7 @@ export default function Main() {
 
       <div className="main__stat-block main__stat-block--last">
         <div className="main__pill main__pill--green">
-          총 {USER.college} 누적 소비 금액
+          총 {user.college} 누적 소비 금액
         </div>
         <p className="main__stat-num">
           91,475<span className="main__stat-unit">원</span>

--- a/src/pages/ReceiptUpload.jsx
+++ b/src/pages/ReceiptUpload.jsx
@@ -7,39 +7,76 @@ import bubbleLeft   from '../assets/icon/bubble-left.svg'
 import bubbleRight  from '../assets/icon/bubble-right.svg'
 import char1        from '../assets/image/3.서브 캐릭터 기본형1 1.svg'
 import char2        from '../assets/image/4.서브 캐릭터 기본형2 1.svg'
+import AlertModal   from '../components/AlertModal'
+import { analyzeReceipt, confirmReceipt } from '../api/receipts'
 
 export default function ReceiptUpload() {
   const navigate = useNavigate()
   const fileInputRef = useRef(null)
   const [isLoading, setIsLoading] = useState(false)
-  const [receiptData, setReceiptData] = useState(null)
+  const [isConfirming, setIsConfirming] = useState(false)
+  const [receiptData, setReceiptData] = useState(null)  // OCR 분석 결과
+  const [imageFile, setImageFile] = useState(null)      // confirm 때 재사용
   const [isConfirmed, setIsConfirmed] = useState(false)
+  const [errorModal, setErrorModal] = useState(null)
 
-  function handleFile(e) {
+  // 1단계: 이미지 선택 → OCR 분석
+  async function handleFile(e) {
     const file = e.target.files[0]
-    if (file) {
-      setIsLoading(true)
-      // TODO: API 연동 — 아래 setTimeout을 실제 API 호출로 교체
-      setTimeout(() => {
-        setReceiptData({
-          storeName: '사랑집',
-          amount: '20,000원',
-          cardCompany: '국민은행',
-        })
-        setIsLoading(false)
-      }, 3000)
+    if (!file) return
+
+    setIsLoading(true)
+    try {
+      const data = await analyzeReceipt(file)
+      setImageFile(file)
+      setReceiptData({
+        storeName: data.storeName,
+        amount: `${data.paymentAmount.toLocaleString()}원`,
+        cardCompany: data.cardCompany,
+        raw: data,  // confirm 전송용 원본 보관
+      })
+    } catch (err) {
+      if (fileInputRef.current) fileInputRef.current.value = ''
+      setErrorModal({ title: '분석 실패', desc: err.message || '잠시 후 다시 시도해주세요' })
+    } finally {
+      setIsLoading(false)
     }
   }
 
+  // 2단계: 사용자 확인 → 최종 저장
+  async function handleConfirm() {
+    if (!imageFile || !receiptData || isConfirming) return
+
+    setIsConfirming(true)
+    try {
+      await confirmReceipt(imageFile, receiptData.raw)
+      setIsConfirmed(true)
+    } catch (err) {
+      setErrorModal({ title: '업로드 실패', desc: err.message || '잠시 후 다시 시도해주세요' })
+    } finally {
+      setIsConfirming(false)
+    }
+  }
+
+  // 다시 찍기: API 호출 없이 상태만 초기화
   function handleRetake() {
     setIsLoading(false)
     setReceiptData(null)
+    setImageFile(null)
     setIsConfirmed(false)
     if (fileInputRef.current) fileInputRef.current.value = ''
   }
 
   return (
     <div className="upload">
+
+      {errorModal && (
+        <AlertModal
+          title={errorModal.title}
+          desc={errorModal.desc}
+          onClose={() => setErrorModal(null)}
+        />
+      )}
 
       {/* ── 헤더 ── */}
       <div className="upload__header">
@@ -139,9 +176,10 @@ export default function ReceiptUpload() {
             <button
               id="btn-upload-finish"
               className="upload__btn upload__btn--blue upload__btn--wide"
-              onClick={() => setIsConfirmed(true)}
+              onClick={handleConfirm}
+              disabled={isConfirming}
             >
-              네, 맞아요
+              {isConfirming ? '저장 중...' : '네, 맞아요'}
             </button>
           </>
         ) : isLoading ? (


### PR DESCRIPTION
## Summary
- 공통 API 클라이언트 유틸 추가 (`src/api/client.js`)
- 로그인·회원가입·아이디 중복확인 API 연동 (`Login.jsx`, `Signup2.jsx`)
- 영수증 업로드를 OCR 분석(`/analyze`) → 사용자 확인 → 최종 저장(`/confirm`) 2단계로 분리
- 메인 대시보드 유저 정보·누적 결제금액 API 연동 (`Main.jsx`)
- 스크롤 시 배경 그라디언트 유지 (`index.css`)

## Test plan
- [ ] 로그인 성공 → `/main` 이동, accessToken localStorage 저장 확인
- [ ] 로그인 실패 → 에러 모달 표시 확인
- [ ] 회원가입 1단계 → 2단계 데이터 정상 전달 확인
- [ ] 아이디 중복확인 → 사용 가능/중복 상태 피드백 확인
- [ ] 회원가입 완료 → `/` 이동 확인
- [ ] 영수증 사진 등록 → OCR 분석 결과 화면 표시 확인
- [ ] 영수증 "다시 찍을래요" → API 호출 없이 초기화 확인
- [ ] 영수증 "네, 맞아요" → `/confirm` 호출 후 완료 화면 전환 확인
- [ ] 메인 화면 유저 이름·단과대·누적 결제금액 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)