### PR TITLE
fix: 로그인 실패, 파비콘/타이틀, PWA 아이콘 버그 수정

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -2,6 +2,7 @@ import { apiRequest } from './client'
 
 export async function login(username, password) {
   const data = await apiRequest('/api/auth/login', {
+    skipAuth: true,
     method: 'POST',
     body: JSON.stringify({ username, password }),
   })
@@ -11,8 +12,9 @@ export async function login(username, password) {
 }
 
 export async function checkUsername(username) {
-  // 200이면 사용 가능, 409면 중복 (apiRequest에서 에러 throw)
-  await apiRequest(`/api/auth/check-username?username=${encodeURIComponent(username)}`)
+  await apiRequest(`/api/auth/check-username?username=${encodeURIComponent(username)}`, {
+    skipAuth: true,
+  })
 }
 
 export async function register({ username, password, passwordConfirm, name, phoneNumber, studentNumber, departmentId, studentCardImage }) {
@@ -26,6 +28,7 @@ export async function register({ username, password, passwordConfirm, name, phon
   formData.append('studentCardImage', studentCardImage)
 
   return apiRequest('/api/auth/register', {
+    skipAuth: true,
     method: 'POST',
     body: formData,
   })

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,23 +1,36 @@
 const BASE_URL = 'https://api.reajoucheck.site'
 
 export async function apiRequest(path, options = {}) {
+  const { skipAuth = false, ...fetchOptions } = options
   const token = localStorage.getItem('accessToken')
 
-  const headers = {
-    ...options.headers,
-  }
+  const headers = { ...fetchOptions.headers }
 
-  if (token) {
+  if (token && !skipAuth) {
     headers['Authorization'] = `Bearer ${token}`
   }
 
   // Content-Type은 FormData일 때 브라우저가 자동 설정하도록 직접 지정하지 않음
-  if (!(options.body instanceof FormData)) {
+  if (!(fetchOptions.body instanceof FormData)) {
     headers['Content-Type'] = 'application/json'
   }
 
-  const res = await fetch(`${BASE_URL}${path}`, { ...options, headers })
-  const json = await res.json()
+  const res = await fetch(`${BASE_URL}${path}`, { ...fetchOptions, headers })
+
+  // 401: 토큰 만료 → 로컬스토리지 초기화 후 로그인 페이지로 이동
+  if (res.status === 401 && !skipAuth) {
+    localStorage.removeItem('accessToken')
+    localStorage.removeItem('refreshToken')
+    window.location.href = '/login'
+    return
+  }
+
+  let json
+  try {
+    json = await res.json()
+  } catch {
+    throw new Error('서버 응답을 처리할 수 없습니다.')
+  }
 
   if (!json.success) {
     const err = new Error(json.message || '요청에 실패했습니다.')

--- a/src/index.css
+++ b/src/index.css
@@ -24,7 +24,7 @@
 
   font: 18px/145% var(--sans);
   letter-spacing: 0.18px;
-  color-scheme: light dark;
+  color-scheme: light;
   color: var(--text);
   background: var(--bg);
   font-synthesis: none;
@@ -59,13 +59,13 @@
 
 html {
   min-height: 100%;
-  background: linear-gradient(to bottom, #4585ff, #b2cbff) no-repeat;
-  background-attachment: fixed;
+  background: #b2cbff; /* 하단 overscroll — 그라디언트 끝 색상 */
 }
 
 body {
   margin: 0;
-  background: transparent;
+  min-height: 100%;
+  background: linear-gradient(to bottom, #4585ff, #b2cbff);
 }
 
 #root {


### PR DESCRIPTION
## #️⃣ Issue Number
- closed #19

## 📝 요약(Summary)

만료된 JWT 토큰으로 인한 로그인 실패, 파비콘/타이틀 미적용, iOS/Android 홈 화면 추가 시 아이콘·앱 설정 미적용 버그를 수정합니다.

- 로그인/회원가입/아이디중복확인 요청 시 만료된 localStorage 토큰이 함께 전송되어 서버가 401을 반환하던 문제 → `skipAuth: true` 옵션으로 해결
- Vercel 배포 후 파비콘 미적용 및 탭 타이틀이 기본값으로 표시되던 문제 → `index.html` 수정
- iOS Safari 홈 화면 추가 및 Android PWA 설치 시 아이콘 미적용 → `apple-touch-icon`, `manifest.json` 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

- `skipAuth: true`는 `apiRequest` 공통 클라이언트에서 토큰 주입 및 401 리디렉션을 모두 건너뜁니다. 인증이 필요 없는 공개 엔드포인트(로그인·회원가입·아이디중복확인)에만 사용합니다.
- 배경 오버스크롤 색상도 함께 그라디언트로 수정했습니다(`index.css`).

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).